### PR TITLE
Block these fucking youtube cookies

### DIFF
--- a/app/home-page.tsx
+++ b/app/home-page.tsx
@@ -155,10 +155,10 @@ function YoutubeVideo({ id }) {
       href={`https://youtu.be/${id}`}
       className="group flex relative items-center justify-center border-0"
     >
-      {/* wrapper around the image to control its size */}
       <img
-        src={`https://img.youtube.com/vi/${id}/0.jpg`}
-        alt={`Youtube video`}
+        // beep-boop-beep - cookie workaround.
+        src={`https://i1.ytimg.com/vi/${id}/0.jpg`}
+        alt={`Youtube video thumbnail`}
         className="w-full h-52 lg:h-56 xl:h-64  object-cover rounded-md"
       />
       <div className="absolute flex w-16 h-16 rounded-full bg-red-600 group-hover:scale-110 group-hover:bg-red-400 transition duration-500 ease-in-out">


### PR DESCRIPTION
The previous domain img.youtube.com was adding cookies on the domain once the users were redirected to the Youtube channel. By using i1.ytimg.com we can avoid cookies. The certificate associated to the domain is emitted by Google Trust Services LLC.